### PR TITLE
Filtered the containers array to only include code-server images

### DIFF
--- a/src/routes/docker.js
+++ b/src/routes/docker.js
@@ -13,9 +13,10 @@ router.get(
       all: true,
       filters: { label: ['multiverse=true'] }
     })
+    const filtered = containers.filter(c => c.Image === 'codercom/code-server')
 
     res.send({
-      containers: containers.map(c => ({
+      containers: filtered.map(c => ({
         name: c.Labels['multiverse.project'],
         id: c.Id,
         running: c.State === 'running',
@@ -32,10 +33,12 @@ router.post(
       all: true,
       filters: { label: ['multiverse=true'] }
     })
+    const filtered = containers.filter(c => c.Image === 'codercom/code-server')
+
     let nameExists
     let portInUse
 
-    containers.forEach(c => {
+    filtered.forEach(c => {
       if (c.Labels['multiverse.project'] === req.body.name) {
         return (nameExists = true)
       }


### PR DESCRIPTION
After realising that removing the docker image filter from #13 that even with filtering labels, users could still manually create none code-server containers and assign the labels. Just in case people do use the `multiverse=true` label, this adds a filter to make sure only code-server containers get through